### PR TITLE
WASAB-858

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wasabi-solana-ts",
-  "version": "0.1.14",
+  "version": "0.1.16",
   "description": "Typescript library for the Wasabi program",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/base/base.ts
+++ b/src/base/base.ts
@@ -6,6 +6,7 @@ export type ProcessResult<T> = {
     accounts: T;
     args?: any;
     setup?: TransactionInstruction[];
+    cleanup?: TransactionInstruction[];
 };
 
 export type ConfigArgs<TArgs, TAccounts> = {
@@ -52,8 +53,12 @@ export async function handleMethodCall<TArgs = void, TAccounts = any, TProgramAc
 
     return args.mode === 'instruction'
         ? builder
-              .instruction()
-              .then((ix: TransactionInstruction) => [...(processed.setup || []), ix])
+            .instruction()
+            .then((ix: TransactionInstruction) => [
+                ...(processed.setup || []),
+                ix,
+                ...(processed.cleanup || [])
+            ])
         : builder.rpc();
 }
 

--- a/src/instructions/closeLongPosition.ts
+++ b/src/instructions/closeLongPosition.ts
@@ -49,23 +49,23 @@ const closeLongPositionSetupConfig: BaseMethodConfig<
         return {
             accounts: config.strict
                 ? {
-                      owner: allAccounts.owner,
-                      closePositionSetup: {
-                          ...allAccounts
-                      }
-                  }
+                    owner: allAccounts.owner,
+                    closePositionSetup: {
+                        ...allAccounts
+                    }
+                }
                 : {
-                      owner: allAccounts.owner,
-                      closePositionSetup: {
-                          owner: allAccounts.owner,
-                          pool: allAccounts.pool,
-                          collateral: allAccounts.collateral,
-                          position: allAccounts.position,
-                          permission: allAccounts.permission,
-                          authority: allAccounts.authority,
-                          tokenProgram: allAccounts.tokenProgram
-                      }
-                  },
+                    owner: allAccounts.owner,
+                    closePositionSetup: {
+                        owner: allAccounts.owner,
+                        pool: allAccounts.pool,
+                        collateral: allAccounts.collateral,
+                        position: allAccounts.position,
+                        permission: allAccounts.permission,
+                        authority: allAccounts.authority,
+                        tokenProgram: allAccounts.tokenProgram
+                    }
+                },
             args: transformArgs(config.args)
         };
     },
@@ -91,25 +91,25 @@ const closeLongPositionCleanupConfig: BaseMethodConfig<
         return {
             accounts: config.strict
                 ? {
-                      owner: allAccounts.owner,
-                      closePositionCleanup: {
-                          ...allAccounts
-                      }
-                  }
+                    owner: allAccounts.owner,
+                    closePositionCleanup: {
+                        ...allAccounts
+                    }
+                }
                 : {
-                      owner: allAccounts.owner,
-                      closePositionCleanup: {
-                          owner: allAccounts.owner,
-                          pool: allAccounts.pool,
-                          position: allAccounts.position,
-                          currency: allAccounts.currency,
-                          collateral: allAccounts.collateral,
-                          authority: allAccounts.authority,
-                          feeWallet: allAccounts.feeWallet,
-                          collateralTokenProgram: allAccounts.collateralTokenProgram,
-                          currencyTokenProgram: allAccounts.currencyTokenProgram
-                      }
-                  }
+                    owner: allAccounts.owner,
+                    closePositionCleanup: {
+                        owner: allAccounts.owner,
+                        pool: allAccounts.pool,
+                        position: allAccounts.position,
+                        currency: allAccounts.currency,
+                        collateral: allAccounts.collateral,
+                        authority: allAccounts.authority,
+                        feeWallet: allAccounts.feeWallet,
+                        collateralTokenProgram: allAccounts.collateralTokenProgram,
+                        currencyTokenProgram: allAccounts.currencyTokenProgram
+                    }
+                }
         };
     },
     getMethod: (program) => () => program.methods.closeLongPositionCleanup()

--- a/src/instructions/closeLongPosition.ts
+++ b/src/instructions/closeLongPosition.ts
@@ -41,7 +41,7 @@ const closeLongPositionSetupConfig: BaseMethodConfig<
     CloseLongPositionSetupInstructionAccounts | CloseLongPositionSetupInstructionAccountsStrict
 > = {
     process: async (config: ConfigArgs<ClosePositionSetupArgs, ClosePositionSetupAccounts>) => {
-        const allAccounts = await getClosePositionSetupInstructionAccounts(
+        const { accounts, ixes }= await getClosePositionSetupInstructionAccounts(
             config.program,
             config.accounts
         );
@@ -49,24 +49,26 @@ const closeLongPositionSetupConfig: BaseMethodConfig<
         return {
             accounts: config.strict
                 ? {
-                    owner: allAccounts.owner,
+                    owner: accounts.owner,
                     closePositionSetup: {
-                        ...allAccounts
+                        ...accounts
                     }
                 }
                 : {
-                    owner: allAccounts.owner,
+                    owner: accounts.owner,
                     closePositionSetup: {
-                        owner: allAccounts.owner,
-                        pool: allAccounts.pool,
-                        collateral: allAccounts.collateral,
-                        position: allAccounts.position,
-                        permission: allAccounts.permission,
-                        authority: allAccounts.authority,
-                        tokenProgram: allAccounts.tokenProgram
+                        owner: accounts.owner,
+                        pool: accounts.pool,
+                        collateral: accounts.collateral,
+                        position: accounts.position,
+                        permission: accounts.permission,
+                        authority: accounts.authority,
+                        tokenProgram: accounts.tokenProgram
                     }
                 },
-            args: transformArgs(config.args)
+            args: transformArgs(config.args),
+            setup: ixes.setupIx,
+            cleanup: ixes.cleanupIx,
         };
     },
     getMethod: (program) => (args) =>
@@ -84,32 +86,34 @@ const closeLongPositionCleanupConfig: BaseMethodConfig<
     CloseLongPositionCleanupInstructionAccounts | CloseLongPositionCleanupInstructionAccountsStrict
 > = {
     process: async (config: ConfigArgs<void, ClosePositionCleanupAccounts>) => {
-        const allAccounts = await getClosePositionCleanupInstructionAccounts(
+        const { accounts, ixes } = await getClosePositionCleanupInstructionAccounts(
             config.program,
             config.accounts
         );
         return {
             accounts: config.strict
                 ? {
-                    owner: allAccounts.owner,
+                    owner: accounts.owner,
                     closePositionCleanup: {
-                        ...allAccounts
+                        ...accounts
                     }
                 }
                 : {
-                    owner: allAccounts.owner,
+                    owner: accounts.owner,
                     closePositionCleanup: {
-                        owner: allAccounts.owner,
-                        pool: allAccounts.pool,
-                        position: allAccounts.position,
-                        currency: allAccounts.currency,
-                        collateral: allAccounts.collateral,
-                        authority: allAccounts.authority,
-                        feeWallet: allAccounts.feeWallet,
-                        collateralTokenProgram: allAccounts.collateralTokenProgram,
-                        currencyTokenProgram: allAccounts.currencyTokenProgram
+                        owner: accounts.owner,
+                        pool: accounts.pool,
+                        position: accounts.position,
+                        currency: accounts.currency,
+                        collateral: accounts.collateral,
+                        authority: accounts.authority,
+                        feeWallet: accounts.feeWallet,
+                        collateralTokenProgram: accounts.collateralTokenProgram,
+                        currencyTokenProgram: accounts.currencyTokenProgram
                     }
-                }
+                },
+            setup: ixes.setupIx,
+            cleanup: ixes.cleanupIx,
         };
     },
     getMethod: (program) => () => program.methods.closeLongPositionCleanup()

--- a/src/instructions/closeShortPosition.ts
+++ b/src/instructions/closeShortPosition.ts
@@ -85,35 +85,37 @@ const closeShortPositionCleanupConfig: BaseMethodConfig<
     | CloseShortPositionCleanupInstructionAccountsStrict
 > = {
     process: async (config: ConfigArgs<void, ClosePositionCleanupAccounts>) => {
-        const allAccounts = await getClosePositionCleanupInstructionAccounts(
+        const { accounts, ixes } = await getClosePositionCleanupInstructionAccounts(
             config.program,
             config.accounts
         );
         return {
             accounts: config.strict
                 ? {
-                    owner: allAccounts.owner,
-                    ownerCollateralAccount: allAccounts.ownerCollateralAccount,
-                    collateral: allAccounts.collateral,
-                    collateralTokenProgram: allAccounts.collateralTokenProgram,
+                    owner: accounts.owner,
+                    ownerCollateralAccount: accounts.ownerCollateralAccount,
+                    collateral: accounts.collateral,
+                    collateralTokenProgram: accounts.collateralTokenProgram,
                     closePositionCleanup: {
-                        ...allAccounts
+                        ...accounts
                     }
                 }
                 : {
-                    owner: allAccounts.owner,
+                    owner: accounts.owner,
                     closePositionCleanup: {
-                        owner: allAccounts.owner,
-                        pool: allAccounts.pool,
-                        position: allAccounts.position,
-                        currency: allAccounts.currency,
-                        collateral: allAccounts.collateral,
-                        authority: allAccounts.authority,
-                        feeWallet: allAccounts.feeWallet,
-                        collateralTokenProgram: allAccounts.collateralTokenProgram,
-                        currencyTokenProgram: allAccounts.currencyTokenProgram
+                        owner: accounts.owner,
+                        pool: accounts.pool,
+                        position: accounts.position,
+                        currency: accounts.currency,
+                        collateral: accounts.collateral,
+                        authority: accounts.authority,
+                        feeWallet: accounts.feeWallet,
+                        collateralTokenProgram: accounts.collateralTokenProgram,
+                        currencyTokenProgram: accounts.currencyTokenProgram
                     }
-                }
+                },
+            setup: ixes.setupIx,
+            cleanup: ixes.cleanupIx,
         };
     },
     getMethod: (program) => () => program.methods.closeShortPositionCleanup()

--- a/src/instructions/deposit.ts
+++ b/src/instructions/deposit.ts
@@ -19,8 +19,8 @@ import {
     TokenInstructionAccounts,
     TokenInstructionAccountsStrict,
     getTokenInstructionAccounts,
-    handleDepositMintWrapSol,
 } from './tokenAccounts';
+import { handleMint } from '../utils';
 import { WasabiSolana } from '../idl/wasabi_solana';
 
 const depositConfig: BaseMethodConfig<
@@ -31,14 +31,15 @@ const depositConfig: BaseMethodConfig<
     process: async (config: ConfigArgs<DepositArgs, DepositAccounts>) => {
         const setup: TransactionInstruction[] = [];
         const {
-            assetMint,
-            assetTokenProgram,
+            mint,
+            tokenProgram,
             setupIx,
             cleanupIx,
-        } = await handleDepositMintWrapSol(
+        } = await handleMint(
             config.program.provider.connection,
-            config.program.provider.publicKey,
             config.accounts.assetMint,
+            config.program.provider.publicKey,
+            'wrap',
             config.args.amount,
         );
 
@@ -46,8 +47,8 @@ const depositConfig: BaseMethodConfig<
 
         const allAccounts = await getTokenInstructionAccounts(
             config.program,
-            assetMint,
-            assetTokenProgram
+            mint,
+            tokenProgram
         );
 
         const ownerShares = await config.program.provider.connection.getAccountInfo(
@@ -72,8 +73,8 @@ const depositConfig: BaseMethodConfig<
                 : {
                     owner: config.program.provider.publicKey,
                     lpVault: allAccounts.lpVault,
-                    assetMint: config.accounts.assetMint,
-                    assetTokenProgram
+                    assetMint: mint,
+                    assetTokenProgram: tokenProgram,
                 },
             args: config.args ? new BN(config.args.amount) : undefined,
             setup,

--- a/src/instructions/initLongPool.ts
+++ b/src/instructions/initLongPool.ts
@@ -25,13 +25,13 @@ const initLongPoolConfig: BaseMethodConfig<
             accounts: config.strict
                 ? allAccounts
                 : {
-                      payer: allAccounts.payer,
-                      permission: allAccounts.permission,
-                      collateral: allAccounts.collateral,
-                      currency: allAccounts.currency,
-                      collateralTokenProgram: allAccounts.collateralTokenProgram,
-                      currencyTokenProgram: allAccounts.currencyTokenProgram
-                  }
+                    payer: allAccounts.payer,
+                    permission: allAccounts.permission,
+                    collateral: allAccounts.collateral,
+                    currency: allAccounts.currency,
+                    collateralTokenProgram: allAccounts.collateralTokenProgram,
+                    currencyTokenProgram: allAccounts.currencyTokenProgram
+                }
         };
     },
     getMethod: (program) => () => program.methods.initLongPool()

--- a/src/instructions/mint.ts
+++ b/src/instructions/mint.ts
@@ -12,8 +12,8 @@ import {
     TokenInstructionAccounts,
     TokenInstructionAccountsStrict,
     getTokenInstructionAccounts,
-    handleDepositMintWrapSol,
 } from './tokenAccounts';
+import { handleMint } from '../utils';
 import { WasabiSolana } from '../idl/wasabi_solana';
 
 export const mintConfig: BaseMethodConfig<
@@ -23,21 +23,22 @@ export const mintConfig: BaseMethodConfig<
 > = {
     process: async (config: ConfigArgs<MintArgs, MintAccounts>) => {
         const {
-            assetMint,
-            assetTokenProgram,
+            mint,
+            tokenProgram,
             setupIx,
             cleanupIx,
-        } = await handleDepositMintWrapSol(
+        } = await handleMint(
             config.program.provider.connection,
-            config.program.provider.publicKey,
             config.accounts.assetMint,
+            config.program.provider.publicKey,
+            'wrap',
             config.args.amount,
         );
 
         const allAccounts = await getTokenInstructionAccounts(
             config.program,
-            assetMint,
-            assetTokenProgram
+            mint,
+            tokenProgram,
         );
 
         return {
@@ -46,8 +47,8 @@ export const mintConfig: BaseMethodConfig<
                 : {
                     owner: config.program.provider.publicKey,
                     lpVault: allAccounts.lpVault,
-                    assetMint: config.accounts.assetMint,
-                    assetTokenProgram
+                    assetMint: mint,
+                    assetTokenProgram: tokenProgram,
                 },
             args: config.args ? new BN(config.args.amount) : undefined,
             setup: setupIx,

--- a/src/instructions/redeem.ts
+++ b/src/instructions/redeem.ts
@@ -3,11 +3,11 @@ import {
     TransactionSignature,
     TransactionInstruction
 } from '@solana/web3.js';
-import { 
-    BaseMethodConfig, 
-    ConfigArgs, 
-    handleMethodCall, 
-    constructMethodCallArgs 
+import {
+    BaseMethodConfig,
+    ConfigArgs,
+    handleMethodCall,
+    constructMethodCallArgs
 } from '../base';
 import {
     RedeemArgs,
@@ -15,8 +15,8 @@ import {
     TokenInstructionAccounts,
     TokenInstructionAccountsStrict,
     getTokenInstructionAccounts,
-    handleWithdrawRedeemUnwrapSol,
 } from './tokenAccounts';
+import { handleMint } from '../utils';
 import { WasabiSolana } from '../idl/wasabi_solana';
 
 export const redeemConfig: BaseMethodConfig<
@@ -26,21 +26,21 @@ export const redeemConfig: BaseMethodConfig<
 > = {
     process: async (config: ConfigArgs<RedeemArgs, RedeemAccounts>) => {
         const {
-            assetMint,
-            assetTokenProgram,
+            mint,
+            tokenProgram,
             setupIx,
             cleanupIx,
-        } = await handleWithdrawRedeemUnwrapSol(
+        } = await handleMint(
             config.program.provider.connection,
-            config.program.provider.publicKey,
             config.accounts.assetMint,
-            config.args.amount
+            config.program.provider.publicKey,
+            'unwrap',
         );
 
         const allAccounts = await getTokenInstructionAccounts(
             config.program,
-            assetMint,
-            assetTokenProgram
+            mint,
+            tokenProgram
         );
 
         return {
@@ -49,8 +49,8 @@ export const redeemConfig: BaseMethodConfig<
                 : {
                     owner: config.program.provider.publicKey,
                     lpVault: allAccounts.lpVault,
-                    assetMint: config.accounts.assetMint,
-                    assetTokenProgram
+                    assetMint: mint,
+                    assetTokenProgram: tokenProgram
                 },
             args: config.args ? new BN(config.args.amount) : undefined,
             setup: setupIx,

--- a/src/instructions/redeem.ts
+++ b/src/instructions/redeem.ts
@@ -1,14 +1,22 @@
 import { Program, BN } from '@coral-xyz/anchor';
-import { TransactionSignature, TransactionInstruction } from '@solana/web3.js';
-import { BaseMethodConfig, ConfigArgs, handleMethodCall, constructMethodCallArgs } from '../base';
+import {
+    TransactionSignature,
+    TransactionInstruction
+} from '@solana/web3.js';
+import { 
+    BaseMethodConfig, 
+    ConfigArgs, 
+    handleMethodCall, 
+    constructMethodCallArgs 
+} from '../base';
 import {
     RedeemArgs,
     RedeemAccounts,
     TokenInstructionAccounts,
     TokenInstructionAccountsStrict,
-    getTokenInstructionAccounts
+    getTokenInstructionAccounts,
+    handleWithdrawRedeemUnwrapSol,
 } from './tokenAccounts';
-import { getTokenProgram } from '../utils';
 import { WasabiSolana } from '../idl/wasabi_solana';
 
 export const redeemConfig: BaseMethodConfig<
@@ -17,14 +25,21 @@ export const redeemConfig: BaseMethodConfig<
     TokenInstructionAccounts | TokenInstructionAccountsStrict
 > = {
     process: async (config: ConfigArgs<RedeemArgs, RedeemAccounts>) => {
-        const assetTokenProgram = await getTokenProgram(
+        const {
+            assetMint,
+            assetTokenProgram,
+            setupIx,
+            cleanupIx,
+        } = await handleWithdrawRedeemUnwrapSol(
             config.program.provider.connection,
-            config.accounts.assetMint
+            config.program.provider.publicKey,
+            config.accounts.assetMint,
+            config.args.amount
         );
 
         const allAccounts = await getTokenInstructionAccounts(
             config.program,
-            config.accounts.assetMint,
+            assetMint,
             assetTokenProgram
         );
 
@@ -32,12 +47,14 @@ export const redeemConfig: BaseMethodConfig<
             accounts: config.strict
                 ? allAccounts
                 : {
-                      owner: config.program.provider.publicKey,
-                      lpVault: allAccounts.lpVault,
-                      assetMint: config.accounts.assetMint,
-                      assetTokenProgram
-                  },
-            args: config.args ? new BN(config.args.amount) : undefined
+                    owner: config.program.provider.publicKey,
+                    lpVault: allAccounts.lpVault,
+                    assetMint: config.accounts.assetMint,
+                    assetTokenProgram
+                },
+            args: config.args ? new BN(config.args.amount) : undefined,
+            setup: setupIx,
+            cleanup: cleanupIx,
         };
     },
     getMethod: (program) => (args) => program.methods.redeem(args)

--- a/src/instructions/tokenAccounts.ts
+++ b/src/instructions/tokenAccounts.ts
@@ -1,7 +1,23 @@
 import { Program } from '@coral-xyz/anchor';
-import { PublicKey } from '@solana/web3.js';
-import { PDA, WASABI_PROGRAM_ID } from '../utils';
-import { getAssociatedTokenAddressSync, TOKEN_2022_PROGRAM_ID } from '@solana/spl-token';
+import {
+    TransactionInstruction,
+    Connection,
+    PublicKey
+} from '@solana/web3.js';
+import {
+    PDA,
+    WASABI_PROGRAM_ID,
+    isSOL,
+    handleSOL,
+    getTokenProgram,
+    createUnwrapSolInstruction,
+    createWrapSolInstruction,
+} from '../utils';
+import {
+    createAssociatedTokenAccountInstruction,
+    getAssociatedTokenAddressSync,
+    TOKEN_2022_PROGRAM_ID,
+} from '@solana/spl-token';
 import { WasabiSolana } from '../idl/wasabi_solana';
 
 type TokenArgs = {
@@ -72,4 +88,103 @@ export async function getTokenInstructionAccounts(
         eventAuthority: PDA.getEventAuthority(),
         program: WASABI_PROGRAM_ID
     };
+}
+
+export async function handleWithdrawRedeemUnwrapSol(
+    connection: Connection,
+    owner: PublicKey,
+    assetMint: PublicKey,
+    amount: number,
+): Promise<{
+    assetMint: PublicKey,
+    assetTokenProgram: PublicKey,
+    setupIx: TransactionInstruction[],
+    cleanupIx: TransactionInstruction[],
+}> {
+    const setup: TransactionInstruction[] = [];
+    const cleanup: TransactionInstruction[] = [];
+    let assetTokenProgram: PublicKey;
+
+    if (isSOL(assetMint)) {
+        const { setupIx, cleanupIx } = await createUnwrapSolInstruction(
+            connection,
+            owner,
+            amount
+        );
+        setup.push(...setupIx);
+        cleanup.push(...cleanupIx);
+        const { tokenProgram, nativeMint } = handleSOL();
+        assetTokenProgram = tokenProgram;
+        assetMint = nativeMint;
+    } else {
+        assetTokenProgram = await getTokenProgram(
+            connection,
+            assetMint,
+        );
+        const ownerAssetAta = getAssociatedTokenAddressSync(
+            assetMint,
+            owner,
+            false,
+            assetTokenProgram
+        );
+        const ownerAssetAccount = await connection.getAccountInfo(ownerAssetAta);
+        if (!ownerAssetAccount) {
+            setup.push(
+                createAssociatedTokenAccountInstruction(
+                    owner,
+                    ownerAssetAta,
+                    owner,
+                    assetMint,
+                    assetTokenProgram,
+                )
+            );
+        }
+    }
+
+    return {
+        assetMint,
+        assetTokenProgram,
+        setupIx: setup,
+        cleanupIx: cleanup,
+    }
+}
+
+export async function handleDepositMintWrapSol(
+    connection: Connection,
+    owner: PublicKey,
+    assetMint: PublicKey,
+    amount: number,
+): Promise<{
+    assetMint: PublicKey,
+    assetTokenProgram: PublicKey,
+    setupIx: TransactionInstruction[],
+    cleanupIx: TransactionInstruction[],
+}> {
+    const setup: TransactionInstruction[] = [];
+    const cleanup: TransactionInstruction[] = [];
+    let assetTokenProgram: PublicKey;
+    if (isSOL(assetMint)) {
+        const { setupIx, cleanupIx } = await createWrapSolInstruction(
+            connection,
+            owner,
+            amount
+        );
+        setup.push(...setupIx);
+        cleanup.push(...cleanupIx);
+        const { tokenProgram, nativeMint } = handleSOL();
+        assetTokenProgram = tokenProgram;
+        assetMint = nativeMint;
+    } else {
+        assetTokenProgram = await getTokenProgram(
+            connection,
+            assetMint
+        );
+    }
+
+    return {
+        assetMint,
+        assetTokenProgram,
+        setupIx: setup,
+        cleanupIx: cleanup,
+    }
 }

--- a/src/instructions/withdraw.ts
+++ b/src/instructions/withdraw.ts
@@ -3,11 +3,11 @@ import {
     TransactionSignature,
     TransactionInstruction
 } from '@solana/web3.js';
-import { 
-    BaseMethodConfig, 
-    handleMethodCall, 
-    ConfigArgs, 
-    constructMethodCallArgs 
+import {
+    BaseMethodConfig,
+    handleMethodCall,
+    ConfigArgs,
+    constructMethodCallArgs
 } from '../base';
 import {
     WithdrawArgs,
@@ -15,8 +15,8 @@ import {
     TokenInstructionAccounts,
     TokenInstructionAccountsStrict,
     getTokenInstructionAccounts,
-    handleWithdrawRedeemUnwrapSol,
 } from './tokenAccounts';
+import { handleMint } from '../utils';
 import { WasabiSolana } from '../idl/wasabi_solana';
 
 export const withdrawConfig: BaseMethodConfig<
@@ -26,21 +26,21 @@ export const withdrawConfig: BaseMethodConfig<
 > = {
     process: async (config: ConfigArgs<WithdrawArgs, WithdrawAccounts>) => {
         const {
-            assetMint,
-            assetTokenProgram,
+            mint,
+            tokenProgram,
             setupIx,
             cleanupIx,
-        } = await handleWithdrawRedeemUnwrapSol(
+        } = await handleMint(
             config.program.provider.connection,
-            config.program.provider.publicKey,
             config.accounts.assetMint,
-            config.args.amount,
+            config.program.provider.publicKey,
+            'unwrap',
         );
 
         const allAccounts = await getTokenInstructionAccounts(
             config.program,
-            assetMint,
-            assetTokenProgram
+            mint,
+            tokenProgram
         );
 
         return {
@@ -49,8 +49,8 @@ export const withdrawConfig: BaseMethodConfig<
                 : {
                     owner: config.program.provider.publicKey,
                     lpVault: allAccounts.lpVault,
-                    assetMint: config.accounts.assetMint,
-                    assetTokenProgram
+                    assetMint: mint,
+                    assetTokenProgram: tokenProgram
                 },
             args: config.args ? new BN(config.args.amount) : undefined,
             setup: setupIx,


### PR DESCRIPTION
Handles wrapping and unwrapping SOL. 

To handle wrapping SOL - we first check to see if the token mint is equal to `SOL_MINT`, if it is we create an associated token account with the `spl-token`'s `NATIVE_MINT`. We then transfer the desired amount of SOL 'into' this account and call a `sync_native` instruction.
After the relevant program instructions are executed we close this account returning the SOL used for opening the account back to the user. 

To handle unwrapping SOL we basically perform the same actions but on the cleanup of a trade.